### PR TITLE
test target must be :: to be compatible with platform test. 

### DIFF
--- a/tasks/containers/Makefile
+++ b/tasks/containers/Makefile
@@ -52,5 +52,5 @@ docker/aws_ecr_login:
 
 
 .PHONY: test
-test : build
+test :: build
 	@echo "[Not Implemented] Running test target"


### PR DESCRIPTION
both : and :: cannot co-exist together. Was getting the below error

```
components/Makefile:19: *** target file `test' has both : and :: entries.  Stop.
```